### PR TITLE
Update SDIMV.spec

### DIFF
--- a/SDIMV.spec
+++ b/SDIMV.spec
@@ -34,5 +34,5 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    icon=['emu.ico'],
+    icon=['icon/emu.ico'],
 )


### PR DESCRIPTION
Fixed icon path in SDIMV.spec file

Updated the icon path from 'emu.ico' to 'icon/emu.ico' to resolve a FileNotFoundError during .exe file generation with PyInstaller. This change ensures that PyInstaller correctly locates the icon file in the 'icon' subfolder.